### PR TITLE
Optimize: 150s => 10s.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 jdk:
   - openjdk8
 script: 
-  - sbt ^test ^publishLocal
+  - sbt ^test ^scripted ^publishLocal
   - find $HOME/.sbt -name "*.lock" | xargs rm
   - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
   - rm -Rf $HOME/.ivy2/cache/scala_2.10/sbt_0.13/org.scala-sbt/sbt-duplicates-finder

--- a/build.sbt
+++ b/build.sbt
@@ -14,3 +14,18 @@ scalacOptions := Seq(
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 
 scalafmtOnCompile := true
+
+libraryDependencies += {
+  val utestVersion = scalaBinaryVersion.value match {
+    case "2.10" | "2.11" => "0.6.8"
+    case _ => "0.7.4"
+  }
+  "com.lihaoyi" %% "utest" % utestVersion % Test
+}
+testFrameworks += new TestFramework("utest.runner.Framework")
+
+enablePlugins(SbtPlugin)
+scriptedLaunchOpts := {
+  scriptedLaunchOpts.value ++
+    Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+}

--- a/src/main/scala/com/github/sbt/duplicates/Checksum.scala
+++ b/src/main/scala/com/github/sbt/duplicates/Checksum.scala
@@ -1,5 +1,0 @@
-package com.github.sbt.duplicates
-
-import sbt.File
-
-case class Checksum(source: File, checksum: String)

--- a/src/main/scala/com/github/sbt/duplicates/Classpath.scala
+++ b/src/main/scala/com/github/sbt/duplicates/Classpath.scala
@@ -12,8 +12,8 @@ case class Classpath(classpath: Seq[File], excludePatterns: Seq[String]) {
   val classesDuplicates             = findDuplicates(allClassesChecksums).toList
   val resourcesDuplicates           = findDuplicates(allResourcesChecksums).toList
 
-  private def sourcesAndChecksumsByName(classpathElements: Seq[Map[String, Checksum]]) =
-    classpathElements.foldLeft(Map.empty[String, List[Checksum]]) {
+  private def sourcesAndChecksumsByName(classpathElements: Seq[Map[String, ClasspathEntity]]) =
+    classpathElements.foldLeft(Map.empty[String, List[ClasspathEntity]]) {
       case (map, checksums) =>
         checksums.foldLeft(map) {
           case (m, (name, checksum)) =>
@@ -22,7 +22,7 @@ case class Classpath(classpath: Seq[File], excludePatterns: Seq[String]) {
         }
     }
 
-  private def findDuplicates(allChecksums: Map[String, List[Checksum]]): Iterable[Conflict] =
+  private def findDuplicates(allChecksums: Map[String, List[ClasspathEntity]]): Iterable[Conflict] =
     allChecksums
       .filter { case (name, checksums) => checksums.size >= 2 && !excludePatterns.exists(r => name.matches(r)) }
       .flatMap {

--- a/src/main/scala/com/github/sbt/duplicates/ClasspathElement.scala
+++ b/src/main/scala/com/github/sbt/duplicates/ClasspathElement.scala
@@ -1,55 +1,38 @@
 package com.github.sbt.duplicates
 
-import java.security.MessageDigest
+import sbt._
 
 import scala.collection.JavaConverters._
-import sbt._
 
 object ClasspathElement {
 
   def apply(base: File): ClasspathElement =
     if (base.isDirectory) buildFromDirectory(base) else buildFromJar(base)
 
-  private def apply(base: File, classes: Seq[String], resources: Seq[String]): ClasspathElement =
-    ClasspathElement(base, classes.map(c => computeSha(base, c)).toMap, resources.map(r => computeSha(base, r)).toMap)
-
-  private def buildFromDirectory(base: File): ClasspathElement = {
-    val (classes, resources) =
-      base.**(-DirectoryFilter).pair(Compat.relativeTo(base)).map(_._2).partition(_.endsWith(".class"))
+  private def apply(base: File, entries: Seq[ClasspathEntity]): ClasspathElement = {
+    val (classes, resources) = entries.partition(_.name.endsWith(".class"))
     ClasspathElement(base, classes, resources)
   }
 
+  private def buildFromDirectory(base: File): ClasspathElement =
+    ClasspathElement(
+      base,
+      base.**(-DirectoryFilter).pair(Compat.relativeTo(base)).map(_._2).map(new FileEntity(base, _))
+    )
+
   private def buildFromJar(base: File): ClasspathElement =
-    Compat.Using.zipFile(base) { zip =>
-      val (classes, resources) =
-        zip.entries().asScala.filterNot(_.isDirectory).map(_.getName).toList.partition(_.endsWith(".class"))
-      ClasspathElement(base, classes, resources)
-    }
-
-  private def computeSha(base: File, path: String): (String, String) = {
-    def sha(bytes: Array[Byte]): String = {
-      val md          = MessageDigest.getInstance("SHA-256")
-      val digestBytes = md.digest(bytes)
-      digestBytes.map(byte => f"$byte%02X").foldLeft(StringBuilder.newBuilder)(_ append _).mkString
-    }
-
-    if (base.isDirectory)
-      path -> sha(IO.readBytes(base / path))
-    else
-      Compat.Using.zipFile(base) { zipFile =>
-        Option(zipFile.getEntry(path))
-          .map(zipFile.getInputStream)
-          .map(IO.readBytes)
-          .map(bytes => path -> sha(bytes))
-          .getOrElse(throw new IllegalStateException(s"Could not get $path from $base"))
+    ClasspathElement(
+      base,
+      Compat.Using.zipFile(base) { zip =>
+        zip.entries().asScala.filterNot(_.isDirectory).map(e => new ZipEntity(base, e.getName)).toList
       }
-
-  }
+    )
 }
-case class ClasspathElement(source: File, classes: Map[String, String], resources: Map[String, String]) {
-  def classesChecksums: Map[String, Checksum]   = checksums(classes)
-  def resourcesChecksums: Map[String, Checksum] = checksums(resources)
 
-  private def checksums(map: Map[String, String]): Map[String, Checksum] =
-    map.map { case (k, v) => k -> Checksum(source, v) }
+case class ClasspathElement(source: File, classes: Seq[ClasspathEntity], resources: Seq[ClasspathEntity]) {
+  def classesChecksums: Map[String, ClasspathEntity]   = byPath(classes)
+  def resourcesChecksums: Map[String, ClasspathEntity] = byPath(resources)
+
+  private def byPath(entries: Seq[ClasspathEntity]): Map[String, ClasspathEntity] =
+    entries.map(entry => entry.name -> entry).toMap
 }

--- a/src/main/scala/com/github/sbt/duplicates/ClasspathEntity.scala
+++ b/src/main/scala/com/github/sbt/duplicates/ClasspathEntity.scala
@@ -1,0 +1,80 @@
+package com.github.sbt.duplicates
+
+import java.io.InputStream
+import java.nio.file.Files
+import java.security.{DigestInputStream, MessageDigest}
+
+import sbt._
+
+/**
+  * Lazy & comparable handle to a class or resource within a zip file or directory.
+  * Caches the checksum.
+  * Falls back to reading the full file contents if absolutely necessary.
+  */
+sealed trait ClasspathEntity {
+
+  /**
+    * Name of the zip file or directory.
+    */
+  def source: File
+
+  /**
+    * Path within the zip file or directory.
+    *
+    * @example `scala/None$.class`
+    * @example `META-INF/MANIFEST.MF`
+    */
+  def name: String
+
+  /**
+    * The content of the class file or resource.
+    */
+  protected def withInputStream[T](f: InputStream => T): T
+
+  lazy val sha256: Seq[Byte] =
+    withInputStream { in =>
+      val buf = Array.ofDim[Byte](8192)
+      val dis = new DigestInputStream(in, MessageDigest.getInstance("SHA-256"))
+      while (dis.read(buf) != -1) {}
+      dis.getMessageDigest.digest().toSeq
+    }
+
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case null => false
+      case other: ClasspathEntity =>
+        name == other.name && sha256 == other.sha256
+      case _ => false
+    }
+
+  override def hashCode: Int =
+    // just for completeness
+    sha256(0) & 0xff |
+      sha256(1) & 0xff << 8 |
+      sha256(2) & 0xff << 16 |
+      sha256(3) & 0xff << 24
+
+  override def toString: String = s"$source/$name"
+}
+
+final class ZipEntity(
+    val source: File,
+    val name: String
+) extends ClasspathEntity {
+
+  override protected def withInputStream[T](f: InputStream => T): T =
+    Compat.Using.zipFile(source) { zipFile =>
+      Option(zipFile.getEntry(name))
+        .map(entry => Compat.Using.bufferedInputStream(zipFile.getInputStream(entry))(f))
+        .getOrElse(throw new IllegalStateException(s"Could not get $name from $source"))
+    }
+}
+
+final class FileEntity(
+    val source: File,
+    val name: String
+) extends ClasspathEntity {
+
+  override protected def withInputStream[T](f: InputStream => T): T =
+    Compat.Using.bufferedInputStream(Files.newInputStream((source / name).toPath))(f)
+}

--- a/src/main/scala/com/github/sbt/duplicates/DuplicatesFinderPlugin.scala
+++ b/src/main/scala/com/github/sbt/duplicates/DuplicatesFinderPlugin.scala
@@ -71,7 +71,7 @@ object DuplicatesFinderPlugin extends AutoPlugin {
     val classpath           = Classpath(fullClasspath.value.files ++ additionalClasspath, excludePatterns.value)
 
     Seq(classpath.classesDuplicates, classpath.resourcesDuplicates)
-      .map(_.filter(conflict => !(reportIfSameContent && conflict.conflictState == ConflictState.ContentEqual)))
+      .map(_.filter(conflict => conflict.conflictState == ConflictState.ContentDiffer || reportIfSameContent))
   }
 
   private def createLogLines(duplicates: List[Conflict], name: String): Seq[String] = {

--- a/src/sbt-test/sanity/sanity/build.sbt
+++ b/src/sbt-test/sanity/sanity/build.sbt
@@ -1,0 +1,6 @@
+organization in ThisBuild := "com.github.sbt.test"
+scalaVersion in ThisBuild := "2.11.12"
+
+val core = project
+val differ = project.dependsOn(core)
+val equal = project.dependsOn(core)

--- a/src/sbt-test/sanity/sanity/core/src/main/scala/ConflictingFile.scala
+++ b/src/sbt-test/sanity/sanity/core/src/main/scala/ConflictingFile.scala
@@ -1,0 +1,4 @@
+class ConflictingFile {
+
+  def core = true
+}

--- a/src/sbt-test/sanity/sanity/differ/src/main/scala/ConflictingFile.scala
+++ b/src/sbt-test/sanity/sanity/differ/src/main/scala/ConflictingFile.scala
@@ -1,0 +1,4 @@
+class ConflictingFile {
+
+  def different = true
+}

--- a/src/sbt-test/sanity/sanity/equal/src/main/scala/ConflictingFile.scala
+++ b/src/sbt-test/sanity/sanity/equal/src/main/scala/ConflictingFile.scala
@@ -1,0 +1,4 @@
+class ConflictingFile {
+
+  def core = true
+}

--- a/src/sbt-test/sanity/sanity/project/plugins.sbt
+++ b/src/sbt-test/sanity/sanity/project/plugins.sbt
@@ -1,0 +1,9 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+  else addSbtPlugin("com.github.sbt" % "sbt-duplicates-finder" % pluginVersion)
+}

--- a/src/sbt-test/sanity/sanity/test
+++ b/src/sbt-test/sanity/sanity/test
@@ -1,0 +1,35 @@
+# =========================================================
+# No conflicting files
+# =========================================================
+> core/checkDuplicatesTest
+
+# =========================================================
+# Same filename, different contents:
+# =========================================================
+# Fails because the contents differ
+-> differ/checkDuplicatesTest
+
+# reportDuplicatesWithSameContent does not matter because contents aren't equal.
+> 'set reportDuplicatesWithSameContent in differ in Compile := true'
+-> differ/checkDuplicatesTest
+
+# excludePatterns ignores the conflict
+> reload
+> 'set excludePatterns in differ in Compile += "ConflictingFile.class"'
+> differ/checkDuplicatesTest
+
+# =========================================================
+# Same filename, equal contents:
+# =========================================================
+# Passes because the contents are equal
+> equal/checkDuplicatesTest
+
+# Fails when told to report on equal files
+> 'set reportDuplicatesWithSameContent in equal in Compile := true'
+-> equal/checkDuplicatesTest
+
+# Passes if we fail on equal files, but exclude the equal file explicitly.
+> reload
+> 'set reportDuplicatesWithSameContent in equal in Compile := true'
+> 'set excludePatterns in equal in Compile += "ConflictingFile.class"'
+> equal/checkDuplicatesTest

--- a/src/test/scala-sbt-0.13/com/github/sbt/duplicates/TestCompat.scala
+++ b/src/test/scala-sbt-0.13/com/github/sbt/duplicates/TestCompat.scala
@@ -1,0 +1,5 @@
+package com.github.sbt.duplicates
+
+object TestCompat {
+  val SbtIO = sbt.IO
+}

--- a/src/test/scala-sbt-1.0/com/github/sbt/duplicates/TestCompat.scala
+++ b/src/test/scala-sbt-1.0/com/github/sbt/duplicates/TestCompat.scala
@@ -1,0 +1,5 @@
+package com.github.sbt.duplicates
+
+object TestCompat {
+  val SbtIO = sbt.io.IO
+}

--- a/src/test/scala/com/github/sbt/duplicates/ClasspathTests.scala
+++ b/src/test/scala/com/github/sbt/duplicates/ClasspathTests.scala
@@ -1,0 +1,39 @@
+package com.github.sbt.duplicates
+
+import com.github.sbt.duplicates.ConflictState._
+import sbt._
+import utest._
+import TestCompat._
+
+object ClasspathTests extends TestSuite {
+
+  val dir = TestCompat.SbtIO.createTemporaryDirectory
+  dir.deleteOnExit()
+  val scalaLibraryJar = dir / "libs" / "scala-library.jar"
+  val classes         = dir / "classes"
+
+  // need a class and jar. the scala library will do.
+  val noneClass = None.getClass
+  SbtIO.transfer(noneClass.getProtectionDomain.getCodeSource.getLocation.openStream(), scalaLibraryJar)
+  SbtIO.transfer(noneClass.getClassLoader.getResourceAsStream("scala/None$.class"), classes / "scala" / "None$.class")
+  SbtIO.write(classes / "scala" / "Some.class", "💥 CONFLICT WITH SCALA-LIBRARY!!!".getBytes)
+  SbtIO.write(classes / "META-INF" / "MANIFEST.MF", "💥 CONFLICT WITH SCALA-LIBRARY!!!")
+
+  override val tests = utest.Tests {
+    "find duplicates" - {
+      val cp      = Classpath(classpath = Seq(scalaLibraryJar, classes), excludePatterns = Nil)
+      val dupeMap = cp.classesDuplicates.groupBy(_.name)
+      assert(
+        dupeMap("scala/None$.class") == List(
+          Conflict("scala/None$.class", List(classes, scalaLibraryJar), ContentEqual)
+        )
+      )
+      assert(
+        dupeMap("scala/Some.class") == List(Conflict("scala/Some.class", List(classes, scalaLibraryJar), ContentDiffer))
+      )
+      dupeMap.size ==> 2
+
+      cp.resourcesDuplicates ==> List(Conflict("META-INF/MANIFEST.MF", List(classes, scalaLibraryJar), ContentDiffer))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Decreases `checkDuplicatesTest` runtime from 150s to 10s by avoiding unnecessary filesystem accesses and hashing.

Added a happy-path unit test for the things I changed.

## Problem
`checkDuplicatesTest` takes roughly 150 seconds to complete on my 27-project build.

CPU usage is quite high:
![checkDuplicatesTest uses maxes out all 12 cpu cores](https://user-images.githubusercontent.com/663139/87760303-89186a80-c7dd-11ea-8325-00ce5d55cdb0.png)

## Other Things I Tried

### Attempt 1: SHA-256 => Murmur
Initially, I suspected the SHA-256 hashing. What else could be burning through so much CPU time?
![1 0 0 hashing](https://user-images.githubusercontent.com/663139/87760693-2378ae00-c7de-11ea-8035-d20fd0f19848.png)

I tried switching to scala's built in Murmur hash function, but it only cut the time down to ~110 seconds.

### Attempt 2: Caching
I figured with 27 projects, there had to be some overlap in my classpath. I dumped `fullClasspath` in each of my projects then flattened:

```
cat **/fullClasspath.txt > all.txt
$ wc -l all.txt
    5495 all.txt
$ cat all.txt | sort | uniq | wc -l
     533
```

So `checkDuplicatesTest` is opening and rehashing each file ~10x. If we had some way to cache the results, we could eliminate this work. But how?

I messed around with a `ConcurrentHashMap`, but couldn't find a good signal to purge it to avoid leaking memory across repeated runs.

I read through [sbt Caching](https://www.scala-sbt.org/1.x/docs/Caching.html), but a few things turned me away.
1. Refactoring - seems like it wants to live at the task level rather than the pure scala level. I didn't want to refactor too much.
2. Filesystem load - looks like it writes to the filesystem. One write per class file seems heavy.

Ultimately, I abandoned the caching approach, since it seems non-trivial to do well.

### Attempt 3: Avoid FS access & hashing
Thinking about FS load, I realized that half of the CPU time is spent in system calls. Is this FS activity?
![1 0 0 system](https://user-images.githubusercontent.com/663139/87760661-1360ce80-c7de-11ea-8f31-43f6d8812f20.png)

Looking deeper, I realized that we're reading and hashing everything, but we only need the hashes if there are multiple files with the same FQCN. Many of these names are unique. We don't need to read or hash these files at all!

I refactored to defer reading the files until after we check if the FQCN is duplicated. I expect that this change was responsible for most of the speedup.

I also spotted that we have a perfectly good CRC32 pre-calculated in the jar/zip central directory. We can grab it for free while traversing the zip entries for the names.

For classes in directories (i.e. outside of jars), we have to compute the CRC32 ourselves, but only if needed on FQCN conflict. I expect the ratio of jars to class files is probably high.

There's some debate on https://stackoverflow.com/q/10953958 about how good CRC32 is as a hash function. (I assume CRC32 and CRC32C perform similarly). It's clearly not as strong as SHA-256, but it also doesn't have to be. On collision, we can just read the whole file contents. Good enough.

### Attempt 4: Back to SHA-256
Thinking further, the CRC32 comparison adds less value than I thought. It only saves IO for the ConflictState.ContentDiffer case. That's the exceptional case rather than the norm since we're probably running checkDuplicatesTest in a CI build. Over the common case, the crc32s will collide and we'll have to go to disk anyway.

checksums.combinations(2).map{ c1 == c2 } perf could regress pathologically badly after my changes in a scenario with lots of duplicates with equal content.

We could replace the combinations with a `checksums.groupBy(_.bytes)` to get back to O(n) disk reads. Simple, but not memory-safe. To get memory safety back, we could either go back to a wide SHA (simple and probabilistically correct) or stream the content and compare bytewise (more complex, faster, 100% correct).

I ended up tossing the CRC32 and bytewise comparison and added back the original SHA-256. Seems like a good balance.

## CLA
I don't see Lightbend CLA checks here, but FWIW, I've signed it previously. You can verify against my akka/akka PRs.